### PR TITLE
chore: fix TS building error

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,14 @@
         "passport-local": "^1.0.0",
         "passport-local-mongoose": "^7.1.2",
         "pug": "^3.0.2",
-        "validator": "^13.7.0"
+        "validator": "^13.7.0",
+        "typescript": "^4.9.5",
+        "@types/connect-flash": "^0.0.37",
+        "@types/express": "^4.17.14",
+        "@types/express-session": "^1.17.5",
+        "@types/method-override": "^0.0.32",
+        "@types/node": "^18.11.9",
+        "@types/passport": "^1.0.11"
     },
     "devDependencies": {
         "@types/connect-flash": "^0.0.37",


### PR DESCRIPTION
- Since TS is a dev dependency it won't install in prod. So, added it as a normal dependency.